### PR TITLE
Allow using template literals to get around escaping

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,6 +19,7 @@ module.exports = {
         "array-callback-return": 0,
         "no-plusplus": 0,
         "max-len": ["error", 150],
+        "quotes": ["error", "single", { "avoidEscape": true, "allowTemplateLiterals": true }],
         "func-names": 0,
         "import/no-extraneous-dependencies": ["error", { "devDependencies": true }],
         "import/prefer-default-export": 0,


### PR DESCRIPTION
Enables `allowTemplateLiterals` in the `quotes` rule.

https://eslint.org/docs/rules/quotes#options