### PR TITLE
chore: disable `prefer-destructuring` for arrays

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,6 +38,18 @@ module.exports = {
         "no-continue": "off",
         "function-paren-newline": 0,
         "import/no-import-module-exports": 0,
-        "no-promise-executor-return": 0
+        "no-promise-executor-return": 0,
+        "prefer-destructuring": ["error", {
+            "VariableDeclarator": {
+                "array": false,
+                "object": true,
+            },
+            "AssignmentExpression": {
+                "array": false,
+                "object": false,
+            }
+        }, {
+            "enforceForRenamedProperties": false,
+        }],
     }
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apify/eslint-config",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "ESLint configuration shared across projects in Apify.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This allows access to array values like this:
```js
value = result[2][1];
```

Right now you have to write it like this, which is unreadable and error-prone:
```js
[, , [, value]] = result;
```