### PR TITLE
Disable `no-return-await`

### DIFF
--- a/index.js
+++ b/index.js
@@ -55,5 +55,6 @@ module.exports = {
         }, {
             "enforceForRenamedProperties": false,
         }],
+        "no-return-await": 0, // So that the functions calling return show up in stack traces in case of an error
     }
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apify/eslint-config",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "ESLint configuration shared across projects in Apify.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
It's making async functions harder to debug, and makes code more error-prone when refactoring it.

E.g. in this case `a()` will not show up in the error stack trace, but `b()` will:
```js
const throws = async () => { throw new Error('oops') }

const a = async () => { return throws() }
const b = async () => { return await throws() }

try { await a() } catch (e) { console.error(e) }
try { await b() } catch (e) { console.error(e) }
```