### PR TITLE
feat: Enable alphabetize for imports

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,6 +28,11 @@ module.exports = {
         "import/prefer-default-export": 0,
         "import/no-unresolved": 0,
         "import/extensions": 0,
+        "import/order": ["error", {
+            "groups": ["builtin", "external", ["parent", "sibling"], "index", "object"],
+            "alphabetize": { "order": "asc", "caseInsensitive": true },
+            "newlines-between": "always",
+        }],
         "class-methods-use-this": 0,
         "strict": 0,
         "object-curly-newline": 0,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apify/eslint-config",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "ESLint configuration shared across projects in Apify.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apify/eslint-config",
-  "version": "0.3.5",
+  "version": "0.4.0",
   "description": "ESLint configuration shared across projects in Apify.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Based off https://github.com/apify/apify-core/blob/develop/src/app/.eslintrc.js#L40-L60

The [rule](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/order.md) is auto-fixable by eslint, so we won't have to do too much manual work (hopefully :D)

Slack discussion for reference https://apifier.slack.com/archives/C01VBUV81UZ/p1688991614682009