### PR TITLE
chore: add CI action to publish a beta version

### DIFF
--- a/.github/workflows/publish_beta.yaml
+++ b/.github/workflows/publish_beta.yaml
@@ -1,0 +1,26 @@
+name: Publish beta
+
+on:
+  workflow_dispatch:
+
+jobs:
+  publish:
+    name: Publish to NPM
+    runs-on: ubuntu-latest
+    steps:
+      -
+        uses: actions/checkout@v4
+      -
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: https://registry.npmjs.org/
+      -
+        name: Install Dependencies
+        run: npm install
+      -
+        name: Bump version to beta
+        run: npm version --preid beta prerelease
+      -
+        name: Publish to NPM
+        run: NODE_AUTH_TOKEN=${{secrets.NPM_TOKEN}} npm publish --tag beta --access public

--- a/.github/workflows/publish_beta.yaml
+++ b/.github/workflows/publish_beta.yaml
@@ -8,19 +8,18 @@ jobs:
     name: Publish to NPM
     runs-on: ubuntu-latest
     steps:
-      -
-        uses: actions/checkout@v4
-      -
-        uses: actions/setup-node@v4
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
         with:
           node-version: 20
           registry-url: https://registry.npmjs.org/
-      -
-        name: Install Dependencies
+
+      - name: Install Dependencies
         run: npm install
-      -
-        name: Bump version to beta
+
+      - name: Bump version to beta
         run: npm version --preid beta prerelease
-      -
-        name: Publish to NPM
+
+      - name: Publish to NPM
         run: NODE_AUTH_TOKEN=${{secrets.NPM_TOKEN}} npm publish --tag beta --access public


### PR DESCRIPTION
This PR introduces a simple action that will publish a beta version of this package. It is intended for testing before we release to the `latest` tag.