### PR TITLE
feat: allow _ args to be unused, stricter devDeps check

### DIFF
--- a/index.js
+++ b/index.js
@@ -99,11 +99,14 @@ module.exports = [...compat.extends('airbnb-base'),
             'lines-between-class-members': ['error', 'always', {
                 exceptAfterSingleLine: true,
             }],
+            // Allow to use underscore as a way to ignore unused args.
+            "no-unused-vars": ["error", { "argsIgnorePattern": "^_" }],
 
             // Rules related to eslint-plugin-import.
             // Force external modules to be specified in the package.json.
             'import/no-extraneous-dependencies': ['error', {
-                devDependencies: true,
+                // Allow devDependencies in test files and folders.
+                devDependencies: ['**/*.test.*', '**/test/**', '**/tests/**'],
             }],
             // Force the use of named exports.
             'import/no-default-export': 'error',
@@ -200,6 +203,8 @@ module.exports = [...compat.extends('airbnb-base'),
             '@typescript-eslint/no-confusing-non-null-assertion': 'error',
             // Prefer "includes()" over "indexOf() !== -1" when checking for existence.
             '@typescript-eslint/prefer-includes': 'error',
+            // Allow to use underscore as a way to ignore unused args.
+            "@typescript-eslint/no-unused-vars": ["error", { "argsIgnorePattern": "^_" }]
         },
     },
 ];


### PR DESCRIPTION
This PR addresses two problems that we have with current config.

First one is using `_` as a way to disable `no-unused-vars` on function args. E.g. sometimes, you want an abstract method with arguments, but you won't use those in the body of the function. Now if you prefix them with `_`, the rule won't complain.

Second was was that `import/no-extraneous-dependencies` was not strict enough. You could have some packages in dev dependencies only and import them from anywhere, the rule wouldn't complain. Now it will only allow import from test files or folders. I'm still not 100% sure that the set of globs I've provided is bulletproof, so suggestions are welcome.