### PR TITLE
fix: allow unused vars from destructuring

### DIFF
--- a/index.js
+++ b/index.js
@@ -99,8 +99,8 @@ module.exports = [...compat.extends('airbnb-base'),
             'lines-between-class-members': ['error', 'always', {
                 exceptAfterSingleLine: true,
             }],
-            // Allow to use underscore as a way to ignore unused args.
-            "no-unused-vars": ["error", { "argsIgnorePattern": "^_" }],
+            // Allow to use underscore as a way to ignore unused args. Allow unused vars from destructuring.
+            "no-unused-vars": ["error", { "argsIgnorePattern": "^_", "ignoreRestSiblings": true }],
 
             // Rules related to eslint-plugin-import.
             // Force external modules to be specified in the package.json.


### PR DESCRIPTION
Adds `ignoreRestSiblings: true` to the `no-unused-vars` rule options. This is important when you want to destructure an object and remove some keys from it, e.g. `const { opt1, ...rest } = options;` so you can pass down just the `rest` and omit properties that shouldn't be there. We use this quite extensively.

https://eslint.org/docs/latest/rules/no-unused-vars#ignorerestsiblings