### PR TITLE
chore: allow devDependencies in eslint.config.mjs

### DIFF
--- a/index.js
+++ b/index.js
@@ -210,7 +210,7 @@ module.exports = [...compat.extends('airbnb-base'),
     },
     // Allow default exports in Jest config files.
     {
-        files: ['**/jest.config.{js,ts}'],
+        files: ['**/jest.config.{js,ts}', '**/jest.config.shared.{js,ts}'],
 
         rules: {
             'import/no-default-export': 'off',

--- a/index.js
+++ b/index.js
@@ -107,7 +107,7 @@ module.exports = [...compat.extends('airbnb-base'),
             // Force external modules to be specified in the package.json.
             'import/no-extraneous-dependencies': ['error', {
                 // Allow devDependencies in test files and folders.
-                devDependencies: ['**/*.test.*', '**/test/**', '**/tests/**', 'eslint.config.mjs'],
+                devDependencies: ['**/*.test.*', '**/test/**', '**/tests/**', 'eslint.config.{mjs,js,cjs,ts,mts,cts}'],
             }],
             // Force the use of named exports.
             'import/no-default-export': 'error',

--- a/index.js
+++ b/index.js
@@ -1,7 +1,6 @@
 const globals = require('globals');
 const js = require('@eslint/js');
 const typescriptEslint = require('typescript-eslint');
-const pluginJest = require('eslint-plugin-jest');
 
 const {
     FlatCompat,
@@ -207,22 +206,4 @@ module.exports = [...compat.extends('airbnb-base'),
             "@typescript-eslint/no-unused-vars": ["error", { "argsIgnorePattern": "^_" }]
         },
     },
-    // Allow default exports in Jest config files.
-    {
-        files: ['**/jest.config.{js,ts}', '**/jest.config.shared.{js,ts}'],
-
-        rules: {
-            'import/no-default-export': 'off',
-        },
-    },
-    {
-        files: ['**/*.spec.{js,ts}', '**/*.test.{js,ts}'],
-        ...pluginJest.configs['flat/recommended'],
-        languageOptions: {
-            globals: pluginJest.environments.globals.globals,
-          },
-          rules: {
-            ...pluginJest.configs['flat/recommended'].rules
-          },
-    }
 ];

--- a/index.js
+++ b/index.js
@@ -22,6 +22,7 @@ module.exports = [...compat.extends('airbnb-base'),
             globals: {
                 ...globals.node,
                 ...globals.browser,
+                ...globals.jest,
             },
 
             ecmaVersion: 2022,
@@ -106,7 +107,7 @@ module.exports = [...compat.extends('airbnb-base'),
             // Force external modules to be specified in the package.json.
             'import/no-extraneous-dependencies': ['error', {
                 // Allow devDependencies in test files and folders.
-                devDependencies: ['**/*.test.*', '**/test/**', '**/tests/**'],
+                devDependencies: ['**/*.test.*', '**/test/**', '**/tests/**', 'eslint.config.mjs'],
             }],
             // Force the use of named exports.
             'import/no-default-export': 'error',
@@ -205,6 +206,14 @@ module.exports = [...compat.extends('airbnb-base'),
             '@typescript-eslint/prefer-includes': 'error',
             // Allow to use underscore as a way to ignore unused args.
             "@typescript-eslint/no-unused-vars": ["error", { "argsIgnorePattern": "^_" }]
+        },
+    },
+    // Allow default exports in Jest config files.
+    {
+        files: ['**/jest.config.js'],
+
+        rules: {
+            'import/no-default-export': 'off',
         },
     },
 ];

--- a/index.js
+++ b/index.js
@@ -210,7 +210,7 @@ module.exports = [...compat.extends('airbnb-base'),
     },
     // Allow default exports in Jest config files.
     {
-        files: ['**/jest.config.js'],
+        files: ['**/jest.config.{js,ts}'],
 
         rules: {
             'import/no-default-export': 'off',

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 const globals = require('globals');
 const js = require('@eslint/js');
 const typescriptEslint = require('typescript-eslint');
+const pluginJest = require('eslint-plugin-jest');
 
 const {
     FlatCompat,
@@ -17,12 +18,10 @@ module.exports = [...compat.extends('airbnb-base'),
         linterOptions: {
             reportUnusedDisableDirectives: true,
         },
-
         languageOptions: {
             globals: {
                 ...globals.node,
                 ...globals.browser,
-                ...globals.jest,
             },
 
             ecmaVersion: 2022,
@@ -216,4 +215,14 @@ module.exports = [...compat.extends('airbnb-base'),
             'import/no-default-export': 'off',
         },
     },
+    {
+        files: ['**/*.spec.{js,ts}', '**/*.test.{js,ts}'],
+        ...pluginJest.configs['flat/recommended'],
+        languageOptions: {
+            globals: pluginJest.environments.globals.globals,
+          },
+          rules: {
+            ...pluginJest.configs['flat/recommended'].rules
+          },
+    }
 ];

--- a/package.json
+++ b/package.json
@@ -10,12 +10,11 @@
     "@eslint/compat": "^1.2.2",
     "eslint-config-airbnb-base": "^15.0.0",
     "eslint-plugin-import": "^2.31.0",
-    "eslint-plugin-jest": "^28.11.0",
     "globals": "^15.11.0"
   },
   "peerDependencies": {
-    "typescript-eslint": "^8.0.0",
-    "eslint": "^9.0.0"
+    "eslint": "^9.0.0",
+    "typescript-eslint": "^8.0.0"
   },
   "peerDependenciesMeta": {
     "typescript-eslint": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "@eslint/compat": "^1.2.2",
     "eslint-config-airbnb-base": "^15.0.0",
     "eslint-plugin-import": "^2.31.0",
+    "eslint-plugin-jest": "^28.11.0",
     "globals": "^15.11.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
This PR allows to have devDependencies in `eslint.config.mjs`