### PR TITLE
feat: split config into subpath exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # apify-eslint-config
 
-This repository contains a shared eslint config used across [Apify](https://apify.com/). The default export contains the JavaScript config. You can also access [TypeScript](https://www.npmjs.com/package/typescript) config via `@apify/eslint-config/ts` and [Jest](https://www.npmjs.com/package/jest) config via `@apify/eslint-config/jest`.
+This repository contains a shared eslint config used across [Apify](https://apify.com/). It offers several configs:
+- JavaScript config `@apify/eslint-config/js`
+- [TypeScript](https://www.npmjs.com/package/typescript) config that also includes JavaScript config `@apify/eslint-config/ts`
+- [Jest](https://www.npmjs.com/package/jest) config that only applies to test files and folders `@apify/eslint-config/jest`
 
 ## How to add to your project
 
@@ -12,18 +15,16 @@ npm install --save-dev @apify/eslint-config eslint
 
 Optionally, you can install `typescript-eslint` or `eslint-plugin-jest` if you intend to use [TypeScript](https://www.npmjs.com/package/typescript) or [Jest](https://www.npmjs.com/package/jest).
 
-Add `eslint.config.js` file, here's an example configuration for a TypeScript project using ESM:
+Add `eslint.config.js` file, here's an example configuration for a TypeScript project using ESM and Jest for tests:
 
 ```js
-import apify from '@apify/eslint-config';
+import apifyTypescriptConfig from '@apify/eslint-config/ts';
 // Optional
-import apifyTypescript from '@apify/eslint-config/ts';
-import apifyJest from '@apify/eslint-config/jest';
+import apifyJestConfig from '@apify/eslint-config/jest';
 
 export default [
-    ...apify,
-    ...apifyTypescript,
-    ...apifyJest,
+    ...apifyTypescriptConfig,
+    ...apifyJestConfig,
     {
         languageOptions: {
             sourceType: 'module',
@@ -33,6 +34,16 @@ export default [
             },
         },
     },
+];
+
+```
+
+An example configuration for a JavaScript project using CommonJS without Jest:
+```js
+const apifyJsConfig = require('@apify/eslint-config/js');
+
+module.exports = [
+    ...apifyJsConfig,
 ];
 
 ```

--- a/README.md
+++ b/README.md
@@ -1,22 +1,29 @@
 # apify-eslint-config
 
-This repository contains a shared eslint config used across Apify. It contains both JS and TS configs.
+This repository contains a shared eslint config used across [Apify](https://apify.com/). The default export contains the JavaScript config. You can also access [TypeScript](https://www.npmjs.com/package/typescript) config via `@apify/eslint-config/ts` and [Jest](https://www.npmjs.com/package/jest) config via `@apify/eslint-config/jest`.
 
 ## How to add to your project
 
 First install the packages as development dependencies:
 
 ```bash
-npm install --save-dev @apify/eslint-config eslint typescript-eslint
+npm install --save-dev @apify/eslint-config eslint
 ```
+
+Optionally, you can install `typescript-eslint` or `eslint-plugin-jest` if you intend to use [TypeScript](https://www.npmjs.com/package/typescript) or [Jest](https://www.npmjs.com/package/jest).
 
 Add `eslint.config.js` file, here's an example configuration for a TypeScript project using ESM:
 
 ```js
 import apify from '@apify/eslint-config';
+// Optional
+import apifyTypescript from '@apify/eslint-config/ts';
+import apifyJest from '@apify/eslint-config/jest';
 
 export default [
     ...apify,
+    ...apifyTypescript,
+    ...apifyJest,
     {
         languageOptions: {
             sourceType: 'module',

--- a/index.js
+++ b/index.js
@@ -1,10 +1,6 @@
-const globals = require('globals');
+const { FlatCompat } = require('@eslint/eslintrc');
 const js = require('@eslint/js');
-const typescriptEslint = require('typescript-eslint');
-
-const {
-    FlatCompat,
-} = require('@eslint/eslintrc');
+const globals = require('globals');
 
 const compat = new FlatCompat({
     baseDirectory: __dirname,
@@ -138,73 +134,6 @@ module.exports = [...compat.extends('airbnb-base'),
                 pathGroupsExcludedImportTypes: ['builtin'],
             }],
             'import/no-import-module-exports': 'off',
-        },
-    },
-    // Configuration for TypeScript files only.
-    // Use the recommended TypeScript configs as a base, follow up with our overrides.
-    ...typescriptEslint.configs.recommended.map((conf) => ({
-        ...conf,
-
-        files: ['**/*.ts', '**/*.tsx', '**/*.mts', '**/*.cts'],
-    })),
-    {
-        files: ['**/*.ts', '**/*.tsx', '**/*.mts', '**/*.cts'],
-
-        plugins: {
-            '@typescript-eslint': typescriptEslint.plugin,
-        },
-
-        languageOptions: {
-            parser: typescriptEslint.parser,
-            ecmaVersion: 2022,
-        },
-
-        rules: {
-            // Note: you must disable the base rule as it can report incorrect errors.
-            'no-shadow': 'off',
-            // This rule extends the base eslint/no-shadow rule. It adds support for TypeScript's this parameters and global augmentation, and adds options for TypeScript features.
-            '@typescript-eslint/no-shadow': ['error'],
-            // Not allowing non-null assertions is overly strict.
-            '@typescript-eslint/no-non-null-assertion': 'off',
-            // Note: you must disable the base rule as it can report incorrect errors.
-            'no-useless-constructor': 'off',
-            // This rule extends the base eslint/no-useless-constructor rule for TypeScript.
-            '@typescript-eslint/no-useless-constructor': 'error',
-            // Note: you must disable the base rule as it can report incorrect errors.
-            'default-param-last': 'off',
-            // This rule extends the base eslint/default-param-last rule for TypeScript.
-            '@typescript-eslint/default-param-last': 'error',
-            // Force promises to be awaited, returned, voided, .then()ed or .catch()ed.
-            '@typescript-eslint/no-floating-promises': 'error',
-            // Disallow the use of promises in places where they shouldn't be used.
-            '@typescript-eslint/await-thenable': 'error',
-            // Do not misuse promises in places like if conditions, or passing them to functions that don't handle promises.
-            '@typescript-eslint/no-misused-promises': ['error', {
-                checksVoidReturn: {
-                    arguments: false,
-                    attributes: false,
-                },
-            }],
-            // Require methods and functions to be marked async if they return a Promise.
-            '@typescript-eslint/promise-function-async': 'error',
-            // Force the usage of "import type" for type imports.
-            '@typescript-eslint/consistent-type-imports': 'error',
-            // Force consistent array type definitions.
-            '@typescript-eslint/array-type': 'error',
-            // Force better grouping of overloaded signatures.
-            '@typescript-eslint/adjacent-overload-signatures': 'error',
-            // Disallow "in" operator with arrays. It is better to use "of".
-            '@typescript-eslint/no-for-in-array': 'error',
-            // Avoid using eval().
-            '@typescript-eslint/no-implied-eval': 'error',
-            // Avoid type specifications that are not necessary.
-            '@typescript-eslint/no-inferrable-types': 'error',
-            // Disallow usage of non-null assertion "!" next to an assignment or equality check.
-            '@typescript-eslint/no-confusing-non-null-assertion': 'error',
-            // Prefer "includes()" over "indexOf() !== -1" when checking for existence.
-            '@typescript-eslint/prefer-includes': 'error',
-            // Allow to use underscore as a way to ignore unused args.
-            "@typescript-eslint/no-unused-vars": ["error", { "argsIgnorePattern": "^_" }]
         },
     },
 ];

--- a/index.js
+++ b/index.js
@@ -19,8 +19,6 @@ module.exports = [...compat.extends('airbnb-base'),
                 ...globals.node,
                 ...globals.browser,
             },
-
-            ecmaVersion: 2022,
         },
 
         rules: {
@@ -96,13 +94,13 @@ module.exports = [...compat.extends('airbnb-base'),
                 exceptAfterSingleLine: true,
             }],
             // Allow to use underscore as a way to ignore unused args. Allow unused vars from destructuring.
-            "no-unused-vars": ["error", { "argsIgnorePattern": "^_", "ignoreRestSiblings": true }],
+            'no-unused-vars': ['error', { 'argsIgnorePattern': '^_', 'ignoreRestSiblings': true }],
 
             // Rules related to eslint-plugin-import.
             // Force external modules to be specified in the package.json.
             'import/no-extraneous-dependencies': ['error', {
                 // Allow devDependencies in test files and folders.
-                devDependencies: ['**/*.test.*', '**/test/**', '**/tests/**'],
+                devDependencies: ['**/*.spec.*', '**/*.test.*', '**/test/**', '**/tests/**'],
             }],
             // Force the use of named exports.
             'import/no-default-export': 'error',

--- a/index.js
+++ b/index.js
@@ -19,6 +19,8 @@ module.exports = [...compat.extends('airbnb-base'),
                 ...globals.node,
                 ...globals.browser,
             },
+
+            ecmaVersion: 'latest',
         },
 
         rules: {

--- a/jest.js
+++ b/jest.js
@@ -3,13 +3,13 @@ const pluginJest = require('eslint-plugin-jest');
 // Configuration for Jest test files only.
 module.exports = [
     {
-        files: ['**/*.spec.{js,ts}', '**/*.test.{js,ts}'],
+        files: ['**/*.spec.*', '**/*.test.*', '**/test/**', '**/tests/**'],
         ...pluginJest.configs['flat/recommended'],
-        languageOptions: {
-            globals: pluginJest.environments.globals.globals,
-          },
-          rules: {
-            ...pluginJest.configs['flat/recommended'].rules
-          },
+        rules: {
+            // Force at least one expect() in each test.
+            'jest/expect-expect': 'error',
+            // Disallow disabled tests.
+            'jest/no-disabled-tests': 'error',
+        }
     },
 ];

--- a/jest.js
+++ b/jest.js
@@ -1,0 +1,15 @@
+const pluginJest = require('eslint-plugin-jest');
+
+// Configuration for Jest test files only.
+module.exports = [
+    {
+        files: ['**/*.spec.{js,ts}', '**/*.test.{js,ts}'],
+        ...pluginJest.configs['flat/recommended'],
+        languageOptions: {
+            globals: pluginJest.environments.globals.globals,
+          },
+          rules: {
+            ...pluginJest.configs['flat/recommended'].rules
+          },
+    },
+];

--- a/jest.js
+++ b/jest.js
@@ -6,6 +6,8 @@ module.exports = [
         files: ['**/*.spec.*', '**/*.test.*', '**/test/**', '**/tests/**'],
         ...pluginJest.configs['flat/recommended'],
         rules: {
+            // Use the recommended rules, but override a few.
+            ...pluginJest.configs['flat/recommended'].rules,
             // Force at least one expect() in each test.
             'jest/expect-expect': 'error',
             // Disallow disabled tests.

--- a/package.json
+++ b/package.json
@@ -6,6 +6,11 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
+  "exports": {
+    ".": "./index.js",
+    "./ts": "./ts.js",
+    "./jest": "./jest.js"
+  },
   "dependencies": {
     "@eslint/compat": "^1.2.2",
     "eslint-config-airbnb-base": "^15.0.0",
@@ -13,11 +18,15 @@
     "globals": "^15.11.0"
   },
   "peerDependencies": {
+    "eslint": "^9.0.0",
     "typescript-eslint": "^8.0.0",
-    "eslint": "^9.0.0"
+    "eslint-plugin-jest": "^28.11.0"
   },
   "peerDependenciesMeta": {
     "typescript-eslint": {
+      "optional": true
+    },
+    "eslint-plugin-jest": {
       "optional": true
     }
   },

--- a/package.json
+++ b/package.json
@@ -16,15 +16,15 @@
     "./jest.js": "./jest.js"
   },
   "dependencies": {
-    "@eslint/compat": "^1.2.2",
+    "@eslint/compat": "^1.2.6",
     "eslint-config-airbnb-base": "^15.0.0",
     "eslint-plugin-import": "^2.31.0",
-    "globals": "^15.11.0"
+    "globals": "^15.14.0"
   },
   "peerDependencies": {
-    "eslint": "^9.0.0",
-    "typescript-eslint": "^8.0.0",
-    "eslint-plugin-jest": "^28.11.0"
+    "eslint": "^9.19.0",
+    "eslint-plugin-jest": "^28.11.0",
+    "typescript-eslint": "^8.23.0"
   },
   "peerDependenciesMeta": {
     "typescript-eslint": {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "exports": {
     ".": "./index.js",
+    "./js": "./index.js",
     "./ts": "./ts.js",
     "./jest": "./jest.js"
   },

--- a/package.json
+++ b/package.json
@@ -9,8 +9,11 @@
   "exports": {
     ".": "./index.js",
     "./js": "./index.js",
+    "./js.js": "./index.js",
     "./ts": "./ts.js",
-    "./jest": "./jest.js"
+    "./ts.js": "./ts.js",
+    "./jest": "./jest.js",
+    "./jest.js": "./jest.js"
   },
   "dependencies": {
     "@eslint/compat": "^1.2.2",

--- a/ts.js
+++ b/ts.js
@@ -1,0 +1,71 @@
+const typescriptEslint = require('typescript-eslint');
+
+// Configuration for TypeScript files only.
+// Use the recommended TypeScript configs as a base, follow up with our overrides.
+module.exports = [
+    ...typescriptEslint.configs.recommended.map((conf) => ({
+        ...conf,
+
+        files: ['**/*.ts', '**/*.tsx', '**/*.mts', '**/*.cts'],
+    })),
+    {
+        files: ['**/*.ts', '**/*.tsx', '**/*.mts', '**/*.cts'],
+
+        plugins: {
+            '@typescript-eslint': typescriptEslint.plugin,
+        },
+
+        languageOptions: {
+            parser: typescriptEslint.parser,
+            ecmaVersion: 2022,
+        },
+
+        rules: {
+            // Note: you must disable the base rule as it can report incorrect errors.
+            'no-shadow': 'off',
+            // This rule extends the base eslint/no-shadow rule. It adds support for TypeScript's this parameters and global augmentation, and adds options for TypeScript features.
+            '@typescript-eslint/no-shadow': ['error'],
+            // Not allowing non-null assertions is overly strict.
+            '@typescript-eslint/no-non-null-assertion': 'off',
+            // Note: you must disable the base rule as it can report incorrect errors.
+            'no-useless-constructor': 'off',
+            // This rule extends the base eslint/no-useless-constructor rule for TypeScript.
+            '@typescript-eslint/no-useless-constructor': 'error',
+            // Note: you must disable the base rule as it can report incorrect errors.
+            'default-param-last': 'off',
+            // This rule extends the base eslint/default-param-last rule for TypeScript.
+            '@typescript-eslint/default-param-last': 'error',
+            // Force promises to be awaited, returned, voided, .then()ed or .catch()ed.
+            '@typescript-eslint/no-floating-promises': 'error',
+            // Disallow the use of promises in places where they shouldn't be used.
+            '@typescript-eslint/await-thenable': 'error',
+            // Do not misuse promises in places like if conditions, or passing them to functions that don't handle promises.
+            '@typescript-eslint/no-misused-promises': ['error', {
+                checksVoidReturn: {
+                    arguments: false,
+                    attributes: false,
+                },
+            }],
+            // Require methods and functions to be marked async if they return a Promise.
+            '@typescript-eslint/promise-function-async': 'error',
+            // Force the usage of "import type" for type imports.
+            '@typescript-eslint/consistent-type-imports': 'error',
+            // Force consistent array type definitions.
+            '@typescript-eslint/array-type': 'error',
+            // Force better grouping of overloaded signatures.
+            '@typescript-eslint/adjacent-overload-signatures': 'error',
+            // Disallow "in" operator with arrays. It is better to use "of".
+            '@typescript-eslint/no-for-in-array': 'error',
+            // Avoid using eval().
+            '@typescript-eslint/no-implied-eval': 'error',
+            // Avoid type specifications that are not necessary.
+            '@typescript-eslint/no-inferrable-types': 'error',
+            // Disallow usage of non-null assertion "!" next to an assignment or equality check.
+            '@typescript-eslint/no-confusing-non-null-assertion': 'error',
+            // Prefer "includes()" over "indexOf() !== -1" when checking for existence.
+            '@typescript-eslint/prefer-includes': 'error',
+            // Allow to use underscore as a way to ignore unused args.
+            "@typescript-eslint/no-unused-vars": ["error", { "argsIgnorePattern": "^_" }]
+        },
+    },
+];

--- a/ts.js
+++ b/ts.js
@@ -1,8 +1,11 @@
+const jsConfig = require('./index.js');
 const typescriptEslint = require('typescript-eslint');
 
-// Configuration for TypeScript files only.
-// Use the recommended TypeScript configs as a base, follow up with our overrides.
+// Configuration that extends the JavaScript config with TypeScript rules.
 module.exports = [
+    // Include our base JavaScript config.
+    ...jsConfig,
+    // Use the recommended TypeScript configs as a base, follow up with our overrides.
     ...typescriptEslint.configs.recommended.map((conf) => ({
         ...conf,
 
@@ -65,7 +68,7 @@ module.exports = [
             // Prefer "includes()" over "indexOf() !== -1" when checking for existence.
             '@typescript-eslint/prefer-includes': 'error',
             // Allow to use underscore as a way to ignore unused args.
-            "@typescript-eslint/no-unused-vars": ["error", { "argsIgnorePattern": "^_" }]
+            '@typescript-eslint/no-unused-vars': ['error', { 'argsIgnorePattern': '^_', 'ignoreRestSiblings': true }],
         },
     },
 ];


### PR DESCRIPTION
This PR introduces split of the config into several subpath exports. It also adds the `jest` configuration that can be used to lint test files using `jest` package.

We'll have 3 configurations, they'll use default exports:
1. `@apify/eslint-config/js`
2. `@apify/eslint-config/ts`, which also includes the JS config
3. `@apify/eslint-config/jest`