### PR TITLE
feat: improve import sorting, add `node:` prefix

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,8 @@
 const { FlatCompat } = require('@eslint/eslintrc');
 const js = require('@eslint/js');
 const globals = require('globals');
+const simpleImportSort = require('eslint-plugin-simple-import-sort');
+const importFixed = require('@jirimoravcik/eslint-plugin-import');
 
 const compat = new FlatCompat({
     baseDirectory: __dirname,
@@ -20,6 +22,11 @@ module.exports = [...compat.extends('airbnb-base'),
             },
 
             ecmaVersion: 'latest',
+        },
+
+        plugins: {
+            'simple-import-sort': simpleImportSort,
+            'import-fixed': importFixed,
         },
 
         rules: {
@@ -110,27 +117,26 @@ module.exports = [...compat.extends('airbnb-base'),
             'import/no-unresolved': 'off',
             // Force extensions for imports. Helps to prevent ESM issues.
             'import/extensions': ['error', 'always'],
+            // Enforce the use of "node:" prefix for Node.js built-in modules.
+            'import-fixed/enforce-node-protocol-usage': ['error', 'always'],
             // Force ordering of imports.
-            'import/order': ['error', {
-                groups: ['builtin', 'external', ['parent', 'sibling'], 'index', 'object'],
-                alphabetize: {
-                    order: 'asc',
-                    caseInsensitive: true,
-                },
-                'newlines-between': 'always',
-                pathGroups: [
-                    {
-                        pattern: '@apify/**',
-                        group: 'external',
-                        position: 'after',
-                    },
-                    {
-                        pattern: '@apify-packages/**',
-                        group: 'external',
-                        position: 'after',
-                    },
+            'import/order': 'off',
+            'simple-import-sort/imports': ['error', {
+                groups: [
+                    // Side effect imports.
+                    ["^\\u0000"],
+                    // Node.js builtins prefixed with `node:`.
+                    ["^node:"],
+                    // Anything not matched in another group.
+                    ["^"],
+                    // Public Apify packages.
+                    ["^@apify/"],
+                    // Private Apify packages.
+                    ["^@apify-packages/"],
+                    // Relative imports.
+                    // Anything that starts with a dot.
+                    ["^\\."],
                 ],
-                pathGroupsExcludedImportTypes: ['builtin'],
             }],
             'import/no-import-module-exports': 'off',
         },

--- a/index.js
+++ b/index.js
@@ -124,18 +124,18 @@ module.exports = [...compat.extends('airbnb-base'),
             'simple-import-sort/imports': ['error', {
                 groups: [
                     // Side effect imports.
-                    ["^\\u0000"],
+                    ['^\\u0000'],
                     // Node.js builtins prefixed with `node:`.
-                    ["^node:"],
+                    ['^node:'],
                     // Anything not matched in another group.
-                    ["^"],
+                    ['^'],
                     // Public Apify packages.
-                    ["^@apify/"],
+                    ['^@apify/'],
                     // Private Apify packages.
-                    ["^@apify-packages/"],
+                    ['^@apify-packages/'],
                     // Relative imports.
                     // Anything that starts with a dot.
-                    ["^\\."],
+                    ['^\\.'],
                 ],
             }],
             'import/no-import-module-exports': 'off',

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@eslint/compat": "^1.2.6",
-    "@jirimoravcik/eslint-plugin-import": "2.32.0-beta.1",
+    "@jirimoravcik/eslint-plugin-import": "2.32.0",
     "eslint-config-airbnb-base": "^15.0.0",
     "eslint-plugin-import": "^2.31.0",
     "eslint-plugin-simple-import-sort": "^12.1.1",

--- a/package.json
+++ b/package.json
@@ -17,8 +17,10 @@
   },
   "dependencies": {
     "@eslint/compat": "^1.2.6",
+    "@jirimoravcik/eslint-plugin-import": "2.32.0-beta.1",
     "eslint-config-airbnb-base": "^15.0.0",
     "eslint-plugin-import": "^2.31.0",
+    "eslint-plugin-simple-import-sort": "^12.1.1",
     "globals": "^15.14.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
This PR adds a new logic for import sorting as `import/order` doesn't work properly and the behavior is considered correct.
We also add a rule to enforce `node:` prefix for modules so we can have nice sorting. (I had to release eslint-plugin-import on my own + fix a bug there, that's why the weird package 😅 )