### PR TITLE
feat: force extensions for type imports

### DIFF
--- a/index.js
+++ b/index.js
@@ -116,7 +116,10 @@ module.exports = [...compat.extends('airbnb-base'),
             'import/prefer-default-export': 'off',
             'import/no-unresolved': 'off',
             // Force extensions for imports. Helps to prevent ESM issues.
-            'import/extensions': ['error', 'always'],
+            'import/extensions': ['error', 'always', {
+                // Force extensions for type imports as well to be consistent.
+                checkTypeImports: true,
+            }],
             // Enforce the use of "node:" prefix for Node.js built-in modules.
             'import-fixed/enforce-node-protocol-usage': ['error', 'always'],
             // Force ordering of imports.


### PR DESCRIPTION
This PR adds `checkTypeImports` to the `import/extensions` rule to force extensions for `type` imports as well. We do this to add consistency as extensions are needed for ESM, so it makes sense to have them for `type` imports. Kudos to @stetizu1 for finding out that we're missing this