### PR TITLE
chore: disable `import/named` for TypeScript files

### DIFF
--- a/ts.js
+++ b/ts.js
@@ -72,6 +72,8 @@ module.exports = [
             // Use TS extension of no-empty-function, e.g. allow to use empty constructors with parameter properties.
             'no-empty-function': 'off',
             '@typescript-eslint/no-empty-function': 'error',
+            // Disable the "import/named" rule for TypeScript files, as suggested by the authors of the plugin.
+            'import/named': 'off',
         },
     },
 ];


### PR DESCRIPTION
This PR disables `import/named` for TS files as suggested by the authors of the plugin https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/named.md#:~:text=This%20rule%20is%20disabled%20in%20the%20%E2%8C%A8%EF%B8%8F%20typescript%20config