### PR TITLE
chore: `error` for `no-console` rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,6 +45,8 @@ module.exports = [...compat.extends('airbnb-base'),
                 ],
                 allowAfterThis: true,
             }],
+            // Error on console usage to prevent accidental debug logging in production code.
+            'no-console': 'error',
             // ++ and -- are fine.
             'no-plusplus': 'off',
             quotes: ['error', 'single', {


### PR DESCRIPTION
This PR changes the `no-console` rule to `error`. Using `warn` didn't make much sense because it still passes CI. If people want to use `console`, they will have to explicitly use `eslint-disable...`, which should prevent accidental debug logs in production code.