### PR TITLE
feat: Add `vitest`-specific config

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ This repository contains a shared eslint config used across [Apify](https://apif
 - JavaScript config `@apify/eslint-config/js`
 - [TypeScript](https://www.npmjs.com/package/typescript) config that also includes JavaScript config `@apify/eslint-config/ts`
 - [Jest](https://www.npmjs.com/package/jest) config that only applies to test files and folders `@apify/eslint-config/jest`
+- [Vitest](https://www.npmjs.com/package/vitest) config that only applies to test files and folders `@apify/eslint-config/vitest`
 
 ## How to add to your project
 
@@ -13,7 +14,10 @@ First install the packages as development dependencies:
 npm install --save-dev @apify/eslint-config eslint
 ```
 
-Optionally, you can install `typescript-eslint` or `eslint-plugin-jest` if you intend to use [TypeScript](https://www.npmjs.com/package/typescript) or [Jest](https://www.npmjs.com/package/jest).
+Optionally, you can install:
+- `typescript-eslint` if you intend to use [TypeScript](https://www.npmjs.com/package/typescript),
+- `eslint-plugin-jest` if you intend to use [Jest](https://www.npmjs.com/package/jest) for testing,
+- `@vitest/eslint-plugin` if you intend to use [Vitest](https://www.npmjs.com/package/vitest) for testing.
 
 Add `eslint.config.js` file, here's an example configuration for a TypeScript project using ESM and Jest for tests:
 
@@ -46,4 +50,15 @@ module.exports = [
     ...apifyJsConfig,
 ];
 
+```
+
+An example configuration for a JavaScript project using ESM and Vitest for tests:
+```js
+import apifyJsConfig from '@apify/eslint-config/js';
+import apifyVitestConfig from '@apify/eslint-config/vitest';
+
+export default [
+    ...apifyJsConfig,
+    ...apifyVitestConfig,
+];
 ```

--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
     "./ts": "./ts.js",
     "./ts.js": "./ts.js",
     "./jest": "./jest.js",
-    "./jest.js": "./jest.js"
+    "./jest.js": "./jest.js",
+    "./vitest": "./vitest.js",
+    "./vitest.js": "./vitest.js"
   },
   "dependencies": {
     "@eslint/compat": "^1.2.6",
@@ -23,11 +25,15 @@
     "globals": "^15.14.0"
   },
   "peerDependencies": {
+    "@vitest/eslint-plugin": "^1.6.14",
     "eslint": "^9.19.0",
     "eslint-plugin-jest": "^28.11.0",
     "typescript-eslint": "^8.23.0"
   },
   "peerDependenciesMeta": {
+    "@vitest/eslint-plugin": {
+      "optional": true
+    },
     "typescript-eslint": {
       "optional": true
     },

--- a/vitest.js
+++ b/vitest.js
@@ -1,0 +1,19 @@
+const pluginVitest = require('@vitest/eslint-plugin');
+
+// Configuration for Vitest test files only.
+module.exports = [
+    {
+        files: ['**/*.spec.*', '**/*.test.*', '**/test/**', '**/tests/**'],
+        plugins: {
+            vitest: pluginVitest,
+        },
+        rules: {
+            // Use the recommended rules, but override a few to keep consistent with the Jest configuration.
+            ...pluginVitest.configs.recommended.rules,
+            // Disallow alias methods like `toBeCalledTimes()` in favor of the more explicit `toHaveBeenCalledTimes()`.
+            'vitest/no-alias-methods': 'error',
+            // Disallow disabled tests.
+            'vitest/no-disabled-tests': 'error',
+        },
+    },
+];


### PR DESCRIPTION
We're migrating away from Jest to Vitest in our other repositories. We want to have a Vitest-specific ESLint config in addition to the Jest-specific one to use in those repos.