### PR TITLE
fix(style): align with apify base config preferences

### DIFF
--- a/style.js
+++ b/style.js
@@ -27,6 +27,16 @@ module.exports = [
         },
 
         rules: {
+            // Disable the legacy eslint stylistic rules that this config replaces
+            // with their `@stylistic/*` equivalents — otherwise both fire on the same
+            // code with different opinions and produce circular fixes.
+            indent: 'off',
+            quotes: 'off',
+            'max-len': 'off',
+            'object-curly-newline': 'off',
+            'lines-between-class-members': 'off',
+            'function-paren-newline': 'off',
+
             '@stylistic/array-bracket-spacing': ['error','never'],
             '@stylistic/arrow-parens': ['error','always'],
             '@stylistic/arrow-spacing': ['error',{before:true,after:true}],
@@ -40,15 +50,17 @@ module.exports = [
             '@stylistic/eol-last': ['error','always'],
             '@stylistic/function-call-spacing': ['error','never'],
             '@stylistic/function-call-argument-newline': ['error','consistent'],
-            '@stylistic/function-paren-newline': ['error','multiline-arguments'],
+            '@stylistic/function-paren-newline': 'off',
             '@stylistic/generator-star-spacing': ['error',{before:false,after:true}],
             '@stylistic/implicit-arrow-linebreak': ['error','beside'],
-            '@stylistic/indent': ['error',2,{SwitchCase:1,VariableDeclarator:1,outerIIFEBody:1,FunctionDeclaration:{parameters:1,body:1},FunctionExpression:{parameters:1,body:1},CallExpression:{arguments:1},ArrayExpression:1,ObjectExpression:1,ImportDeclaration:1,flatTernaryExpressions:false,ignoredNodes:['JSXElement','JSXElement > *','JSXAttribute','JSXIdentifier','JSXNamespacedName','JSXMemberExpression','JSXSpreadAttribute','JSXExpressionContainer','JSXOpeningElement','JSXClosingElement','JSXFragment','JSXOpeningFragment','JSXClosingFragment','JSXText','JSXEmptyExpression','JSXSpreadChild'],ignoreComments:false}],
+            // Apify projects use 4 spaces, not airbnb's 2 — preserved from
+            // the legacy `indent` rule in `index.js`.
+            '@stylistic/indent': ['error', 4, { SwitchCase: 1 }],
             '@stylistic/key-spacing': ['error',{beforeColon:false,afterColon:true}],
             '@stylistic/keyword-spacing': ['error',{before:true,after:true,overrides:{return:{after:true},throw:{after:true},case:{after:true}}}],
             '@stylistic/linebreak-style': ['error','unix'],
-            '@stylistic/lines-between-class-members': ['error','always',{exceptAfterSingleLine:false}],
-            '@stylistic/max-len': ['error',100,2,{ignoreUrls:true,ignoreComments:false,ignoreRegExpLiterals:true,ignoreStrings:true,ignoreTemplateLiterals:true}],
+            '@stylistic/lines-between-class-members': ['error', 'always', { exceptAfterSingleLine: true }],
+            '@stylistic/max-len': ['error', { code: 160, ignoreUrls: true, ignoreTemplateLiterals: true }],
             '@stylistic/new-parens': 'error',
             '@stylistic/newline-per-chained-call': ['error',{ignoreChainWithDepth:4}],
             '@stylistic/no-confusing-arrow': ['error',{allowParens:true}],
@@ -62,14 +74,14 @@ module.exports = [
             '@stylistic/no-trailing-spaces': ['error',{skipBlankLines:false,ignoreComments:false}],
             '@stylistic/no-whitespace-before-property': 'error',
             '@stylistic/nonblock-statement-body-position': ['error','beside',{overrides:{}}],
-            '@stylistic/object-curly-newline': ['error',{ObjectExpression:{minProperties:4,multiline:true,consistent:true},ObjectPattern:{minProperties:4,multiline:true,consistent:true},ImportDeclaration:{minProperties:4,multiline:true,consistent:true},ExportDeclaration:{minProperties:4,multiline:true,consistent:true}}],
+            '@stylistic/object-curly-newline': ['error', { consistent: true }],
             '@stylistic/object-curly-spacing': ['error','always'],
             '@stylistic/object-property-newline': ['error',{allowAllPropertiesOnSameLine:true}],
             '@stylistic/one-var-declaration-per-line': ['error','always'],
             '@stylistic/operator-linebreak': ['error','before',{overrides:{'=':'none'}}],
             '@stylistic/padded-blocks': ['error',{blocks:'never',classes:'never',switches:'never'},{allowSingleLineBlocks:true}],
             '@stylistic/quote-props': ['error','as-needed',{keywords:false,unnecessary:true,numbers:false}],
-            '@stylistic/quotes': ['error','single',{avoidEscape:true}],
+            '@stylistic/quotes': ['error', 'single', { avoidEscape: true, allowTemplateLiterals: true }],
             '@stylistic/rest-spread-spacing': ['error','never'],
             '@stylistic/semi': ['error','always'],
             '@stylistic/semi-spacing': ['error',{before:false,after:true}],


### PR DESCRIPTION
## Why

The opt-in `@apify/eslint-config/style` config (added in #35) blindly copied airbnb-base's stylistic options. Several of those options conflict with apify's *own* preferences, which are already enforced via legacy rules in `index.js` and have been the de-facto Apify code style for years:

| rule                          | airbnb default                 | apify (legacy in `index.js`)            |
|-------------------------------|--------------------------------|------------------------------------------|
| `indent`                      | 2 spaces                       | **4 spaces**, `SwitchCase: 1`            |
| `quotes`                      | single, no template literals   | single, **`allowTemplateLiterals: true`**|
| `max-len`                     | 100 chars                      | **160 chars**                            |
| `object-curly-newline`        | `minProperties: 4` rules       | **`{ consistent: true }`**               |
| `lines-between-class-members` | `exceptAfterSingleLine: false` | **`exceptAfterSingleLine: true`**        |
| `function-paren-newline`      | `multiline-arguments`          | **`'off'`**                              |

When a consumer spreads both configs together:

```js
import apifyTypeScriptConfig from '@apify/eslint-config/ts.js';
import apifyStyleConfig from '@apify/eslint-config/style.js';

export default [
    ...apifyTypeScriptConfig,  // legacy `indent: 4` from index.js
    ...apifyStyleConfig,       // new `@stylistic/indent: 2` from airbnb defaults
];
```

…the legacy `indent: 4` from `index.js` and the new `@stylistic/indent: 2` from `style.js` **both fire** on every indented line, because they're different rule names — neither overrides the other. `eslint --fix` then bounces between the two opinions and gives up with `ESLintCircularFixesWarning`.

I tried this against [`apify-core`](https://github.com/apify/apify-core) (the largest internal consumer) by adding `apifyStyleConfig` to its `eslint.config.mjs`. The result:

```
~360,000 @stylistic/indent errors across 59 lerna workspaces
~17,000 @stylistic/max-len errors
~5,000 @stylistic/object-curly-newline errors
~1,300 @stylistic/quotes errors
~700 @stylistic/lines-between-class-members errors
~550 @stylistic/function-paren-newline errors
```

Almost all of those are on code that's been written in 4-space indent / 160-col / etc. for years. The `style.js` config was effectively saying "rewrite your entire codebase to airbnb's defaults", which was never the intent. The intent was "preserve the legacy airbnb stylistic ruleset for projects that don't use a formatter, with the same options apify was already using."

## What this PR does

1. **Aligns the 6 conflicting `@stylistic/*` rules with apify's pre-existing preferences** from `index.js`. Existing apify codebases pass lint without reformatting the world.

2. **Explicitly turns off the legacy eslint stylistic rules inside `style.js` itself**:

   ```js
   indent: 'off',
   quotes: 'off',
   'max-len': 'off',
   'object-curly-newline': 'off',
   'lines-between-class-members': 'off',
   'function-paren-newline': 'off',
   ```

   This way, when both `index.js` and `style.js` are loaded together, only the `@stylistic/*` versions run and there are no circular fixes. Consumers that use *only* `index.js` (no opt-in style) continue to get the legacy rules unchanged.

## Diff

Just `style.js`, +18 / −6 lines:

```diff
         rules: {
+            // Disable the legacy eslint stylistic rules that this config replaces
+            // with their `@stylistic/*` equivalents — otherwise both fire on the same
+            // code with different opinions and produce circular fixes.
+            indent: 'off',
+            quotes: 'off',
+            'max-len': 'off',
+            'object-curly-newline': 'off',
+            'lines-between-class-members': 'off',
+            'function-paren-newline': 'off',
+
             '@stylistic/array-bracket-spacing': ['error','never'],
             ...
-            '@stylistic/function-paren-newline': ['error','multiline-arguments'],
+            '@stylistic/function-paren-newline': 'off',
             ...
-            '@stylistic/indent': ['error',2,{...huge airbnb config...}],
+            // Apify projects use 4 spaces, not airbnb's 2 — preserved from
+            // the legacy `indent` rule in `index.js`.
+            '@stylistic/indent': ['error', 4, { SwitchCase: 1 }],
             ...
-            '@stylistic/lines-between-class-members': ['error','always',{exceptAfterSingleLine:false}],
-            '@stylistic/max-len': ['error',100,2,{...}],
+            '@stylistic/lines-between-class-members': ['error', 'always', { exceptAfterSingleLine: true }],
+            '@stylistic/max-len': ['error', { code: 160, ignoreUrls: true, ignoreTemplateLiterals: true }],
             ...
-            '@stylistic/object-curly-newline': ['error',{...minProperties: 4 rules...}],
+            '@stylistic/object-curly-newline': ['error', { consistent: true }],
             ...
-            '@stylistic/quotes': ['error','single',{avoidEscape:true}],
+            '@stylistic/quotes': ['error', 'single', { avoidEscape: true, allowTemplateLiterals: true }],
```

## Validation

I'll re-run lint against `apify-core` once this branch is published — the expected outcome is that the 360k+ spurious indent errors disappear, and any *real* stylistic violations (which there will be some of, since apify-core has historically had no stylistic enforcement at all on a few directories) are surfaced legitimately.

## Rollout

Patch release: `v2.0.1`. No breaking changes — this only affects consumers who opt into `@apify/eslint-config/style`, and for them it makes the rules behave the way they probably already expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)