### PR TITLE
fix(style): enable trailing-comma enforcement on TS generics, enums, tuples

### DIFF
--- a/style.js
+++ b/style.js
@@ -42,7 +42,19 @@ module.exports = [
             '@stylistic/arrow-spacing': ['error',{before:true,after:true}],
             '@stylistic/block-spacing': ['error','always'],
             '@stylistic/brace-style': ['error','1tbs',{allowSingleLine:true}],
-            '@stylistic/comma-dangle': ['error',{arrays:'always-multiline',objects:'always-multiline',imports:'always-multiline',exports:'always-multiline',functions:'always-multiline'}],
+            '@stylistic/comma-dangle': ['error', {
+                arrays: 'always-multiline',
+                objects: 'always-multiline',
+                imports: 'always-multiline',
+                exports: 'always-multiline',
+                functions: 'always-multiline',
+                // TS-specific extensions — without these, generic type parameter
+                // lists and enum bodies default to "never", which is inconsistent
+                // with the rest of the multiline-trailing-comma convention.
+                enums: 'always-multiline',
+                generics: 'always-multiline',
+                tuples: 'always-multiline',
+            }],
             '@stylistic/comma-spacing': ['error',{before:false,after:true}],
             '@stylistic/comma-style': ['error','last',{exceptions:{ArrayExpression:false,ArrayPattern:false,ArrowFunctionExpression:false,CallExpression:false,FunctionDeclaration:false,FunctionExpression:false,ImportDeclaration:false,ObjectExpression:false,ObjectPattern:false,VariableDeclaration:false,NewExpression:false}}],
             '@stylistic/computed-property-spacing': ['error','never'],


### PR DESCRIPTION
## Why

`@stylistic/comma-dangle` supports four TypeScript-specific sub-options beyond the JS defaults: `enums`, `generics`, `tuples`, and `attributes`. The previous config only set the five JS sub-options (`arrays`, `objects`, `imports`, `exports`, `functions`) to `always-multiline`, which left the TS-specific ones at their default of `'never'`.

That meant a multi-line generic like:

```ts
function getActor<
    TProjection extends Projection<Actor>,
    TProjectedActor extends object = ...,
    TResultActor = ...,
    TExtendedActor extends ... = ...,  // ← trailing comma
>({ apiToken, actorId, projection } : { ... })
```

…would get its trailing comma after the last generic parameter removed by `eslint --fix`, producing inconsistent style with the rest of the codebase (where multi-line arrays, objects, imports, etc. all keep their trailing commas).

Surfaced when bumping [`apify/apify-core`](https://github.com/apify/apify-core) to v2.0.1 — multiple files had their generic-parameter trailing commas stripped, e.g. `src/api/src/lib/actors.ts:117`.

## What

Adds `enums`, `generics`, and `tuples` to the `@stylistic/comma-dangle` options, all set to `always-multiline` to match the JS sub-options. `attributes` is JSX-specific and intentionally left at default since it doesn't apply to most apify codebases.

```diff
-            '@stylistic/comma-dangle': ['error',{arrays:'always-multiline',objects:'always-multiline',imports:'always-multiline',exports:'always-multiline',functions:'always-multiline'}],
+            '@stylistic/comma-dangle': ['error', {
+                arrays: 'always-multiline',
+                objects: 'always-multiline',
+                imports: 'always-multiline',
+                exports: 'always-multiline',
+                functions: 'always-multiline',
+                // TS-specific extensions — without these, generic type parameter
+                // lists and enum bodies default to "never", which is inconsistent
+                // with the rest of the multiline-trailing-comma convention.
+                enums: 'always-multiline',
+                generics: 'always-multiline',
+                tuples: 'always-multiline',
+            }],
```

Reformatted as multi-line for readability while we're at it.

## Rollout

Patch release: `v2.0.2`. No breaking changes — only affects consumers who opt into `@apify/eslint-config/style`, and for them it makes the rule behave consistently with how it already handles JS multi-line constructs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)