### PR TITLE
feat: switch to eslint-plugin-import-x and allow ESLint 10

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,11 +1,11 @@
 const js = require('@eslint/js');
 const globals = require('globals');
-const pluginImport = require('eslint-plugin-import');
+const pluginImportX = require('eslint-plugin-import-x');
 const simpleImportSort = require('eslint-plugin-simple-import-sort');
 
 module.exports = [
     js.configs.recommended,
-    pluginImport.flatConfigs.recommended,
+    pluginImportX.flatConfigs.recommended,
     {
         linterOptions: {
             reportUnusedDisableDirectives: true,
@@ -172,32 +172,32 @@ module.exports = [
             'symbol-description': 'error',
 
             // ─── Imports ───────────────────────────────────────────────────
-            // These `import/recommended` rules are notoriously noisy in
+            // These `import-x/recommended` rules are notoriously noisy in
             // TypeScript codebases — false positives on namespace re-exports,
             // on libs whose default and named exports overlap (`zod`,
             // `async`, etc.), and on computed property access against
             // imported namespaces. Match airbnb's effective behavior, which
             // had them declared as `error` but they were silently no-op
             // because of how FlatCompat loaded the plugin.
-            'import/no-named-as-default': 'off',
-            'import/no-named-as-default-member': 'off',
-            'import/namespace': 'off',
+            'import-x/no-named-as-default': 'off',
+            'import-x/no-named-as-default-member': 'off',
+            'import-x/namespace': 'off',
             // All imports must come before any other statements.
-            'import/first': 'error',
+            'import-x/first': 'error',
             // No circular imports.
-            'import/no-cycle': ['error', { maxDepth: '∞' }],
+            'import-x/no-cycle': ['error', { maxDepth: '∞' }],
             // No importing yourself.
-            'import/no-self-import': 'error',
+            'import-x/no-self-import': 'error',
             // Exported `let` / `var` is almost always a mistake.
-            'import/no-mutable-exports': 'error',
+            'import-x/no-mutable-exports': 'error',
             // No `./../../foo` if you can write `../foo`.
-            'import/no-useless-path-segments': ['error', { commonjs: true }],
+            'import-x/no-useless-path-segments': ['error', { commonjs: true }],
             // No `import '/abs/path'`.
-            'import/no-absolute-path': 'error',
+            'import-x/no-absolute-path': 'error',
             // No `require(variable)`.
-            'import/no-dynamic-require': 'error',
+            'import-x/no-dynamic-require': 'error',
             // Require a blank line after the import block.
-            'import/newline-after-import': 'error',
+            'import-x/newline-after-import': 'error',
 
             // ─── Apify-specific overrides (existing) ───────────────────────
             indent: ['error', 4, {
@@ -223,6 +223,9 @@ module.exports = [
             'no-plusplus': 'off',
             quotes: ['error', 'single', {
                 avoidEscape: true,
+                // The core ESLint `quotes` rule schema still requires a boolean here;
+                // only `@stylistic/quotes` (in `style.js`) accepts the newer
+                // 'always'/'never' string form.
                 allowTemplateLiterals: true,
             }],
             // It's ok to use functions before they are defined.
@@ -278,26 +281,29 @@ module.exports = [
             // Allow to use underscore as a way to ignore unused args. Allow unused vars from destructuring.
             'no-unused-vars': ['error', { 'argsIgnorePattern': '^_', 'ignoreRestSiblings': true }],
 
-            // Rules related to eslint-plugin-import.
+            // Rules related to eslint-plugin-import-x.
             // Force external modules to be specified in the package.json.
-            'import/no-extraneous-dependencies': ['error', {
+            'import-x/no-extraneous-dependencies': ['error', {
                 // Allow devDependencies in test files and folders. Also in eslint config files.
                 devDependencies: ['**/*.spec.*', '**/*.test.*', '**/test/**', '**/tests/**', 'eslint.config.{mjs,js,cjs,ts,mts,cts}'],
             }],
             // Force the use of named exports.
-            'import/no-default-export': 'error',
+            'import-x/no-default-export': 'error',
             // It's ok to not have a default export and we force named exports anyway.
-            'import/prefer-default-export': 'off',
-            'import/no-unresolved': 'off',
+            'import-x/prefer-default-export': 'off',
+            'import-x/no-unresolved': 'off',
             // Force extensions for imports. Helps to prevent ESM issues.
-            'import/extensions': ['error', 'always', {
+            'import-x/extensions': ['error', 'always', {
                 // Force extensions for type imports as well to be consistent.
                 checkTypeImports: true,
             }],
-            // Enforce the use of "node:" prefix for Node.js built-in modules.
-            'import/enforce-node-protocol-usage': ['error', 'always'],
+            // Note: `enforce-node-protocol-usage` (the rule from `eslint-plugin-import`)
+            // is intentionally not configured here — `eslint-plugin-import-x` does not port
+            // it (see un-ts/eslint-plugin-import-x#200). Consumers who want this check
+            // should add `eslint-plugin-unicorn` and enable `unicorn/prefer-node-protocol`,
+            // or `eslint-plugin-n` and enable `n/prefer-node-protocol`.
             // Force ordering of imports.
-            'import/order': 'off',
+            'import-x/order': 'off',
             'simple-import-sort/imports': ['error', {
                 groups: [
                     // Side effect imports.
@@ -315,7 +321,7 @@ module.exports = [
                     ['^\\.'],
                 ],
             }],
-            'import/no-import-module-exports': 'off',
+            'import-x/no-import-module-exports': 'off',
         },
     },
 ];

--- a/package.json
+++ b/package.json
@@ -23,14 +23,15 @@
     "./style.js": "./style.js"
   },
   "dependencies": {
-    "eslint-plugin-import": "^2.32.0",
+    "eslint-plugin-import-x": "^4.16.2",
     "eslint-plugin-simple-import-sort": "^12.1.1",
     "globals": "^15.14.0"
   },
   "peerDependencies": {
+    "@eslint/js": "^9.19.0 || ^10.0.0",
     "@stylistic/eslint-plugin": "^5.0.0",
     "@vitest/eslint-plugin": "^1.6.14",
-    "eslint": "^9.19.0",
+    "eslint": "^9.19.0 || ^10.0.0",
     "eslint-plugin-jest": "^28.11.0",
     "typescript-eslint": "^8.23.0"
   },

--- a/style.js
+++ b/style.js
@@ -93,7 +93,7 @@ module.exports = [
             '@stylistic/operator-linebreak': ['error','before',{overrides:{'=':'none'}}],
             '@stylistic/padded-blocks': ['error',{blocks:'never',classes:'never',switches:'never'},{allowSingleLineBlocks:true}],
             '@stylistic/quote-props': ['error','as-needed',{keywords:false,unnecessary:true,numbers:false}],
-            '@stylistic/quotes': ['error', 'single', { avoidEscape: true, allowTemplateLiterals: true }],
+            '@stylistic/quotes': ['error', 'single', { avoidEscape: true, allowTemplateLiterals: 'always' }],
             '@stylistic/rest-spread-spacing': ['error','never'],
             '@stylistic/semi': ['error','always'],
             '@stylistic/semi-spacing': ['error',{before:false,after:true}],

--- a/ts.js
+++ b/ts.js
@@ -72,8 +72,8 @@ module.exports = [
             // Use TS extension of no-empty-function, e.g. allow to use empty constructors with parameter properties.
             'no-empty-function': 'off',
             '@typescript-eslint/no-empty-function': 'error',
-            // Disable the "import/named" rule for TypeScript files, as suggested by the authors of the plugin.
-            'import/named': 'off',
+            // Disable the "import-x/named" rule for TypeScript files, as suggested by the authors of the plugin.
+            'import-x/named': 'off',
         },
     },
 ];


### PR DESCRIPTION
## Summary

- Replace `eslint-plugin-import` with the maintained `eslint-plugin-import-x` fork. All `import/*` rules are renamed to `import-x/*`.
- Broaden the `eslint` peer range to `^9.19.0 || ^10.0.0`.
- Add `@eslint/js` as an explicit peer dep — it was being `require()`'d in `index.js` but only resolved by accident through `eslint@9`'s transitive deps. `eslint@10` no longer ships it, so this would have hard-crashed on the first install otherwise.
- Fix the `[@stylistic/eslint-plugin]: deprecated value(boolean) for "allowTemplateLiterals"` warning by switching `@stylistic/quotes` to `'always'`.
- Drop `import/enforce-node-protocol-usage` — import-x doesn't port it ([un-ts/eslint-plugin-import-x#200](https://github.com/un-ts/eslint-plugin-import-x/issues/200)). Consumers who want it can add `unicorn/prefer-node-protocol` or `n/prefer-node-protocol`.

## Why import-x?

`eslint-plugin-import` is essentially unmaintained and still does not declare ESLint 10 support in its peer range ([import-js/eslint-plugin-import#3227](https://github.com/import-js/eslint-plugin-import/issues/3227)). `eslint-plugin-import-x` is the actively maintained fork — same rule names, same flat-config shape, and `peerDependencies.eslint = ^8.57.0 || ^9.0.0 || ^10.0.0` already.

## Consumer migration

Shipping as part of `2.x` per discussion (internal package).

Consumers will need to:

1. Rename any local `import/*` rule overrides in their `eslint.config.*` to `import-x/*`. Affects (at least): `apify-shared-js`, `apify-client-js`, `apify-sdk-js`, `apify-cli`, `crawlee`, `crawlee-v3`, `apify-docs`, `store-website-content-crawler`, `apify-core`.
2. If/when bumping to ESLint 10, add `@eslint/js` to their devDeps.
3. If they relied on `import/enforce-node-protocol-usage`, add `eslint-plugin-unicorn` or `eslint-plugin-n` and enable the equivalent rule.

## Test plan

- [x] Smoke-tested locally: loaded all five exported configs (`js`, `ts`, `js+style`, `js+jest`, `js+vitest`) under `eslint@9.39.4` — no warnings, no errors.
- [x] Smoke-tested locally: same five configs under `eslint@10.2.0` — no warnings, no errors.
- [ ] Bump `@apify/eslint-config` in `apify-core` and verify CI lint jobs no longer emit the `allowTemplateLiterals` deprecation spam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)