### PR TITLE
fix: drop ESLint 10 from peer dep ranges to fix ERESOLVE conflicts

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,10 +28,10 @@
     "globals": "^15.14.0"
   },
   "peerDependencies": {
-    "@eslint/js": "^9.19.0 || ^10.0.0",
+    "@eslint/js": "^9.19.0",
     "@stylistic/eslint-plugin": "^5.0.0",
     "@vitest/eslint-plugin": "^1.6.14",
-    "eslint": "^9.19.0 || ^10.0.0",
+    "eslint": "^9.19.0",
     "eslint-plugin-jest": "^28.11.0",
     "typescript-eslint": "^8.23.0"
   },


### PR DESCRIPTION
## Summary
- Removes `|| ^10.0.0` from both `@eslint/js` and `eslint` peer dependency ranges
- `@eslint/js@10.x` has a peer dependency on `eslint@^10.0.0`, so when npm auto-installs peer deps it can pick `@eslint/js@10.0.1` even when `eslint@9.x` is installed, producing an `ERESOLVE` error
- This broke `npm install` in downstream projects (e.g. [apify/actor-templates#750](https://github.com/apify/actor-templates/pull/750))
- ESLint 10 migration can be done properly in a future release

## Test plan
- [ ] Verify `npm install` succeeds in a project with `eslint@^9.29.0` and `@apify/eslint-config` at this version
- [ ] Verify CI passes on apify/actor-templates#750 after publishing this fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)