### PR TITLE
fix: add eslint-import-resolver-node to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "./style.js": "./style.js"
   },
   "dependencies": {
+    "eslint-import-resolver-node": "^0.3.10",
     "eslint-plugin-import-x": "^4.16.2",
     "eslint-plugin-simple-import-sort": "^12.1.1",
     "globals": "^15.14.0"


### PR DESCRIPTION
## Summary
- Adds `eslint-import-resolver-node` as a direct dependency
- Fixes `EslintPluginImportResolveError: node with invalid interface loaded as resolver` thrown by `import-x/no-cycle` (and other path-resolving rules) in downstream projects

## Root cause
`eslint-plugin-import-x` v4.16.2 has a buggy fallback in `requireResolver`: when the `eslint-import-resolver-node` package isn't installed, it falls back to `path.resolve(baseDir, name)` — so for `name === "node"` it can end up resolving to completely unrelated files (e.g. `node_modules/unicorn-magic/node.js`), loading them as a "resolver", and failing the legacy-interface check.

Depending on `eslint-import-resolver-node` ensures the first `tryRequire` in the plugin succeeds with a valid legacy resolver interface.

## Test plan
- [ ] Verify `npm run lint` passes in apify/actor-templates `js-cypress` template after publishing this fix
- [ ] Verify other templates still lint cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)