### PR TITLE
fix: set import-x/resolver-next with a reusable createNodeResolver instance

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,16 @@ const globals = require('globals');
 const pluginImportX = require('eslint-plugin-import-x');
 const simpleImportSort = require('eslint-plugin-simple-import-sort');
 
+// Opt in to `eslint-plugin-import-x`'s new-style resolver via a single reusable
+// instance. The legacy `node` resolver path (used when `import-x/resolver-next`
+// is not set) constructs a fresh `unrs-resolver.ResolverFactory` on every
+// import resolution, which leaks native memory and OOMs ESLint workers on
+// large monorepos — see un-ts/eslint-plugin-import-x#481. The new path reuses
+// the single `createNodeResolver()` instance passed to `import-x/resolver-next`
+// across all resolutions within a lint run, so the leak is structurally
+// impossible.
+const nodeResolver = pluginImportX.createNodeResolver();
+
 module.exports = [
     js.configs.recommended,
     pluginImportX.flatConfigs.recommended,
@@ -18,6 +28,10 @@ module.exports = [
 
             ecmaVersion: 'latest',
             sourceType: 'module',
+        },
+
+        settings: {
+            'import-x/resolver-next': [nodeResolver],
         },
 
         plugins: {


### PR DESCRIPTION
## Summary

\`eslint-plugin-import-x\`'s legacy \`node\` resolver path — the default fall-through when \`import-x/resolver-next\` is not configured — constructs a fresh \`unrs-resolver.ResolverFactory\` on every import resolution. \`unrs-resolver\` is a Rust binding that allocates native memory invisible to V8 heap limits, so per-call construction causes worker RSS to grow without bound over a lint run.

On a large lerna monorepo (apify/apify-core, ~60 packages, thousands of files), this reliably OOM-killed CI workers within 2 minutes, regardless of how much JS heap we gave them. Bumping \`--max-old-space-size\` didn't help because the leak is in native memory.

## Fix

\`eslint-plugin-import-x\` v4.6.0+ already has proper instance reuse — but only on the new resolver path. You opt in by passing a single reusable \`createNodeResolver()\` instance via \`import-x/resolver-next\`. Since our shared config is the obvious chokepoint, set it here so every consumer gets the fix automatically and nobody has to rediscover the leak via an OOM.

## Context

- un-ts/eslint-plugin-import-x#481 (the leak in the legacy path, and the review feedback pointing to this as the proper fix)
- https://github.com/un-ts/eslint-plugin-import-x/releases/tag/v4.6.0 (release notes where instance reuse landed)
- https://github.com/un-ts/eslint-plugin-import-x/pull/192 (the original upstream PR introducing the new resolver path)

## Verification

Tested on apify-core by configuring the same thing locally in its \`eslint.config.mjs\`. \`npx eslint ./src/packages --concurrency=auto\` with 8 GB heap now completes cleanly where it previously OOM-killed the worker every time.